### PR TITLE
Database implementation

### DIFF
--- a/Source/Database.swift
+++ b/Source/Database.swift
@@ -10,14 +10,18 @@ import Foundation
 
 public class Database  {
     
+    public let name:String
+    private let client:CouchDBClient
     
     init(client:CouchDBClient, dbName:String){
-        
+        name = dbName
+        self.client = client
     }
     
-    // TODO change to CouchDBOperation
-    public func add(operation:NSOperation){
-        
+
+    public func add(operation:CouchDatabaseOperation){
+        operation.databaseName = self.name
+        self.client.addOperation(operation)
     }
     
     

--- a/Source/Database.swift
+++ b/Source/Database.swift
@@ -26,7 +26,19 @@ public class Database  {
     
     
     subscript(key:String) -> Dictionary<String,AnyObject>?{
-        return nil
+        let getDocument = GetDocumentOperation()
+        getDocument.docId = key
+        
+        
+        var doc:[String:AnyObject]?
+        getDocument.getDocumentCompletionBlock = { (document, error ) in
+            doc = document
+        };
+        
+        self.add(getDocument)
+        getDocument.waitUntilFinished()
+        
+        return doc
     }
     
     


### PR DESCRIPTION
Add implementation for Database class functions.

This makes it possible to use the database object to add operations to the queue, this implicitly adds the database name to the operation via the `databaseName` property, as a result any value currently set will be overwritten