### PR TITLE
Fix warnings for swift 2.2

### DIFF
--- a/ObjectiveCloudant.xcodeproj/project.pbxproj
+++ b/ObjectiveCloudant.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		9896FE801BB57DAD00856BD7 /* CreateIndexTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9896FE7F1BB57DAD00856BD7 /* CreateIndexTests.m */; };
 		98A87EE21C6E31DA00D8B0E1 /* CDTOperationRequestBuilderDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 98A87EE01C6E31DA00D8B0E1 /* CDTOperationRequestBuilderDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		98A87EE31C6E31DA00D8B0E1 /* CDTOperationRequestExecutorDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 98A87EE11C6E31DA00D8B0E1 /* CDTOperationRequestExecutorDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		98B4F2CE1CA759130076C5E4 /* PutDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B4F2CD1CA759130076C5E4 /* PutDocumentTests.swift */; };
 		98E5431C1C9CCD0500F02E06 /* InterceptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E5431B1C9CCD0500F02E06 /* InterceptorTests.swift */; };
 		F89766C81C8D8994004C5DAE /* PutDocumentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8ACC9631C8AF3BE00C8650D /* PutDocumentOperation.swift */; };
 /* End PBXBuildFile section */
@@ -190,6 +191,7 @@
 		9896FE7F1BB57DAD00856BD7 /* CreateIndexTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CreateIndexTests.m; path = ObjectiveCloudantTests/CreateIndexTests.m; sourceTree = SOURCE_ROOT; };
 		98A87EE01C6E31DA00D8B0E1 /* CDTOperationRequestBuilderDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDTOperationRequestBuilderDelegate.h; path = ObjectiveCloudant/HTTP/CDTOperationRequestBuilderDelegate.h; sourceTree = SOURCE_ROOT; };
 		98A87EE11C6E31DA00D8B0E1 /* CDTOperationRequestExecutorDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDTOperationRequestExecutorDelegate.h; path = ObjectiveCloudant/HTTP/CDTOperationRequestExecutorDelegate.h; sourceTree = SOURCE_ROOT; };
+		98B4F2CD1CA759130076C5E4 /* PutDocumentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PutDocumentTests.swift; sourceTree = "<group>"; };
 		98E5431B1C9CCD0500F02E06 /* InterceptorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterceptorTests.swift; sourceTree = "<group>"; };
 		9BE38C8FC08AD2F7D5DE29A0 /* Pods-ObjectiveCloudantTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ObjectiveCloudantTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ObjectiveCloudantTests/Pods-ObjectiveCloudantTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C44CC9006A617C35666B7B15 /* Pods-SwiftCloudantTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftCloudantTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftCloudantTests/Pods-SwiftCloudantTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -478,6 +480,7 @@
 			children = (
 				98734A5D1C8A601400E79C5B /* CreateDatabaseTests.swift */,
 				98734A5E1C8A601400E79C5B /* GetDocumentTests.swift */,
+				98B4F2CD1CA759130076C5E4 /* PutDocumentTests.swift */,
 				98734A5F1C8A601400E79C5B /* Info.plist */,
 				98734A601C8A601400E79C5B /* SwiftCloudantTests.swift */,
 				98E5431B1C9CCD0500F02E06 /* InterceptorTests.swift */,
@@ -851,6 +854,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				98B4F2CE1CA759130076C5E4 /* PutDocumentTests.swift in Sources */,
 				98734A611C8A601400E79C5B /* CreateDatabaseTests.swift in Sources */,
 				98734A621C8A601400E79C5B /* GetDocumentTests.swift in Sources */,
 				98734A641C8A601400E79C5B /* SwiftCloudantTests.swift in Sources */,

--- a/Source/HTTP/SessionCookieInterceptor.swift
+++ b/Source/HTTP/SessionCookieInterceptor.swift
@@ -30,12 +30,14 @@ public class SessionCookieInterceptor : HTTPInterceptor
   
     }
     
-    public  func interceptResponse(var ctx: HTTPInterceptorContext) -> HTTPInterceptorContext {
+    public  func interceptResponse(context: HTTPInterceptorContext) -> HTTPInterceptorContext {
         
-        guard let response = ctx.response
+        guard let response = context.response
         else {
-            return ctx;
+            return context;
         }
+        
+        var ctx = context
         
         if response.statusCode == 403 || response.statusCode == 401 {
             ctx.shouldRetry = true

--- a/Source/HTTP/URLSession.swift
+++ b/Source/HTTP/URLSession.swift
@@ -98,7 +98,7 @@ public class URLSessionTask {
             }
             
             if ctx.shouldRetry && self.remainingRetries > 0 {
-                self.remainingRetries--;
+                self.remainingRetries -= 1;
                 self.inProgessTask = self.makeRequest()
                 self.inProgessTask?.resume()
             } else {

--- a/Source/Operations/PutDocumentOperation.swift
+++ b/Source/Operations/PutDocumentOperation.swift
@@ -22,7 +22,7 @@ public class PutDocumentOperation: CouchDatabaseOperation {
     public var revId: String? = nil
     
     /** Body of document. Must be serialisable with NSJSONSerialization */
-    public var body: AnyObject? = nil
+    public var body: [String:AnyObject]? = nil
 
     /**
     Completion block to run when the operation completes.

--- a/Tests/GetDocumentTests.swift
+++ b/Tests/GetDocumentTests.swift
@@ -74,6 +74,7 @@ class GetDocumentTests : XCTestCase {
         waitForExpectationsWithTimeout(10.0, handler: nil)
     }
     
+    
     func testGetDocument() {
         let data = createTestDocuments(1)
         let getDocumentExpectation = expectationWithDescription("get document")

--- a/Tests/PutDocumentTests.swift
+++ b/Tests/PutDocumentTests.swift
@@ -1,0 +1,54 @@
+//
+//  File.swift
+//  ObjectiveCloudant
+//
+//  Created by Rhys Short on 26/03/2016.
+//  Copyright © 2016 Small Text. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import SwiftCloudant
+
+class PutDocumentTests : XCTestCase {
+    let url = "http://localhost:5984"
+    let username: String? = nil
+    let password: String? = nil
+    var client: CouchDBClient? = nil;
+    var dbName: String? = nil
+    
+    override func setUp() {
+        super.setUp()
+        
+        dbName = "a-\(NSUUID().UUIDString.lowercaseString)"
+        self.client = CouchDBClient(url:NSURL(string: url)!, username:username, password:password)
+        let create = CreateDatabaseOperation()
+        create.databaseName = dbName!
+        client!.addOperation(create)
+        create.waitUntilFinished()
+        
+        print("Created database: \(dbName!)")
+    }
+    
+    
+    func testSaveDocument(){
+        let db = self.client![self.dbName!]
+        let putExpectation = self.expectationWithDescription("Put Document expectation")
+        let put = PutDocumentOperation()
+        put.docId = "Doc1"
+        put.body = ["hello":"world"]
+        put.putDocumentCompletionBlock = {(docId,revId,statusCode,error) in
+            putExpectation.fulfill()
+            XCTAssertNotNil(docId)
+            XCTAssertNotNil(revId)
+            XCTAssertEqual(2, statusCode / 100)
+            XCTAssertEqual("Doc1", docId)
+        }
+        db.add(put)
+        
+        self.waitForExpectationsWithTimeout(10) { (_) in
+            
+        }
+        
+    }
+}


### PR DESCRIPTION
Fix warnings introduced in swift 2.2

The interceptResponse for the SessionCookieInterceptor needs to be rethought to ensure it makes sense being able to replace the http context.